### PR TITLE
additional cache options

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,9 +173,14 @@ is suggested) that Approuter is contained in the directory ~/approuter.
   with cacheNU, where N is a numeric value and U is the units. Currently the
   available cache prefixes are as follows:
 
+  * cache1m
+  * cache2m
+  * cache10m
   * cache1h
   * cache2h
   * cache4h
+  * cache1d
+  * cache7d
   * cache365d
 
   These path prefixes can simply be used at the head of your existing paths to

--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -75,6 +75,43 @@ http {
             proxy_cache off;
             proxy_pass http://proxy_to;
         }
+
+        location /cache1m/ {
+            proxy_cache primary_zone;
+            proxy_cache_lock on;
+            proxy_cache_methods GET HEAD POST;
+            # this is the default, but I want to be explicit so it's clear
+            # what's going on here
+            proxy_cache_lock_timeout 5s;
+            proxy_cache_use_stale updating error timeout;
+            proxy_cache_valid 1m;
+            proxy_pass http://proxy_to/;
+        }
+
+        location /cache2m/ {
+            proxy_cache primary_zone;
+            proxy_cache_lock on;
+            proxy_cache_methods GET HEAD POST;
+            # this is the default, but I want to be explicit so it's clear
+            # what's going on here
+            proxy_cache_lock_timeout 5s;
+            proxy_cache_use_stale updating error timeout;
+            proxy_cache_valid 2m;
+            proxy_pass http://proxy_to/;
+        }
+
+        location /cache10m/ {
+            proxy_cache primary_zone;
+            proxy_cache_lock on;
+            proxy_cache_methods GET HEAD POST;
+            # this is the default, but I want to be explicit so it's clear
+            # what's going on here
+            proxy_cache_lock_timeout 5s;
+            proxy_cache_use_stale updating error timeout;
+            proxy_cache_valid 10m;
+            proxy_pass http://proxy_to/;
+        }
+
         location /cache1h/ {
             proxy_cache primary_zone;
             proxy_cache_lock on;
@@ -108,6 +145,30 @@ http {
             proxy_cache_lock_timeout 5s;
             proxy_cache_use_stale updating error timeout;
             proxy_cache_valid 4h;
+            proxy_pass http://proxy_to/;
+        }
+
+        location /cache1d/ {
+            proxy_cache primary_zone;
+            proxy_cache_lock on;
+            proxy_cache_methods GET HEAD POST;
+            # this is the default, but I want to be explicit so it's clear
+            # what's going on here
+            proxy_cache_lock_timeout 5s;
+            proxy_cache_use_stale updating error timeout;
+            proxy_cache_valid 1d;
+            proxy_pass http://proxy_to/;
+        }
+
+        location /cache7d/ {
+            proxy_cache primary_zone;
+            proxy_cache_lock on;
+            proxy_cache_methods GET HEAD POST;
+            # this is the default, but I want to be explicit so it's clear
+            # what's going on here
+            proxy_cache_lock_timeout 5s;
+            proxy_cache_use_stale updating error timeout;
+            proxy_cache_valid 7d;
             proxy_pass http://proxy_to/;
         }
 


### PR DESCRIPTION
We'd like to get additional cache options to be used by epiquery for smaller db queries that will run more frequently from a variety of clients as we push more work (and essentially server functionality) into end users browsers.  This will allow us to provide fresher data to end users while not unnecessarily clobbering the database.

For good measure, threw is some additional cache durations that seemed worthy (like 1d and 7d).
